### PR TITLE
more name creation guidelines

### DIFF
--- a/src/content/STEP_0.js
+++ b/src/content/STEP_0.js
@@ -22,7 +22,11 @@ export const STEP_0 = {
     <p>
       Nedenfor har vi samlet noen spørsmål og svar som forklarer litt mer om Dapla-team og prosessen med å komme
       i gang. Vi anbefaler at du leser gjennom disse før du starter veilederen. Send oss gjerne flere spørsmål
-      på <a href="https://ssb-norge.slack.com/archives/C015E7B4YS0">#hjelp_dapla</a> dersom noe er uklart.
+      i kanalen <a href="https://ssb-norge.slack.com/archives/C015E7B4YS0">#hjelp_dapla</a> på Slack dersom noe er
+      uklart.
+    </p>
+    <p>Hvis du ikke har tilgang til Slack kan du alternativt sende en epost
+      til <a href="mailto:hjelp_dapla-aaaace52ybb7ih4k4mdp5sj7yy@ssb-norge.slack.com">denne adressen</a>.
     </p>
   </>
 }

--- a/src/content/STEP_1.js
+++ b/src/content/STEP_1.js
@@ -1,7 +1,7 @@
 export const STEP_1 = {
   TEXT: <>
     <p>
-      Navnet på et Dapla-team bør reflektere <em>domene - subdomene</em>.
+      Navnet på et Dapla-team bør reflektere <em>domene og subdomene</em>.
       Her er noen eksempler på eksisterende teamnavn:
     </p>
     <ul>
@@ -9,5 +9,18 @@ export const STEP_1 = {
       <li>Team Skatt Næring</li>
       <li>Team Kostra KVM</li>
     </ul>
+    <p>"Skatt" vil da være et eksempel på et domene, mens "Person" og "Næring" er eksempler på subdomener under samme domene.</p>
+    <h2>Lengde og forkortelser</h2>
+    <p>
+      Delen av navnet som beskriver domene og subdomene (for eksempel "Skatt Person"), kan i seg selv IKKE overskride 25 tegn!
+      Dersom navnet til teamet er langt anbefaler vi å forkorte den mest generelle delen av navnet til et trebokstavers "flyplassnavn".
+      For eksempel, "Grunnopplæring Grunnskole" som er 25 tegn kan bli til "GRO Grunnskole" som er 14 tegn.
+      Dersom domenet allerede er en forkortelse eller sammenslåing (f.eks. "Kostra" for "Kommune Stat Raportering") kan
+      man bruke en "flyplassnavn" for subdomenet istedenfor for å korte ned navnet, slik "Kostra KVM" har gjort.
+    </p>
+    <p>
+      <b>NB:</b> Dersom det finnes andre team i deres domene som er eller skal på Dapla,
+      vær sikker på at dere bruker samme "flyplassnavn" for domenet når dere opretter team.
+    </p>
   </>
 }

--- a/src/content/STEP_1.js
+++ b/src/content/STEP_1.js
@@ -15,7 +15,7 @@ export const STEP_1 = {
       Delen av navnet som beskriver domene og subdomene (for eksempel "Skatt Person"), kan i seg selv IKKE overskride 25 tegn!
       Dersom navnet til teamet er langt anbefaler vi å forkorte den mest generelle delen av navnet til et trebokstavers "flyplassnavn".
       For eksempel, "Grunnopplæring Grunnskole" som er 25 tegn kan bli til "GRO Grunnskole" som er 14 tegn.
-      Dersom domenet allerede er en forkortelse eller sammenslåing (f.eks. "Kostra" for "Kommune Stat Raportering") kan
+      Dersom domenet allerede er en forkortelse eller sammenslåing (f.eks. "Kostra" for "Kommune Stat Rapportering") kan
       man bruke en "flyplassnavn" for subdomenet istedenfor for å korte ned navnet, slik "Kostra KVM" har gjort.
     </p>
     <p>

--- a/src/content/STEP_1.js
+++ b/src/content/STEP_1.js
@@ -20,7 +20,7 @@ export const STEP_1 = {
     </p>
     <p>
       <b>NB:</b> Dersom det finnes andre team i deres domene som er eller skal på Dapla,
-      vær sikker på at dere bruker samme "flyplassnavn" for domenet når dere opretter team.
+      vær sikker på at dere bruker samme "flyplassnavn" for domenet når dere oppretter team.
     </p>
   </>
 }

--- a/src/content/STEP_1.js
+++ b/src/content/STEP_1.js
@@ -16,7 +16,7 @@ export const STEP_1 = {
       Dersom navnet til teamet er langt anbefaler vi å forkorte den mest generelle delen av navnet til et trebokstavers "flyplassnavn".
       For eksempel, "Grunnopplæring Grunnskole" som er 25 tegn kan bli til "GRO Grunnskole" som er 14 tegn.
       Dersom domenet allerede er en forkortelse eller sammenslåing (f.eks. "Kostra" for "Kommune Stat Rapportering") kan
-      man bruke en "flyplassnavn" for subdomenet istedenfor for å korte ned navnet, slik "Kostra KVM" har gjort.
+      man bruke et "flyplassnavn" for subdomenet istedenfor for å korte ned navnet, slik "Kostra KVM" har gjort.
     </p>
     <p>
       <b>NB:</b> Dersom det finnes andre team i deres domene som er eller skal på Dapla,

--- a/src/content/WIZARD.js
+++ b/src/content/WIZARD.js
@@ -4,12 +4,12 @@ export const WIZARD = {
   TEAM_NAME: {
     title: 'Teamnavn',
     description: <>
-      Teamets navn (f. eks: Team Brunost).
+      Teamets navn (f. eks: "Team Pålegg Brunost").
       <b> Dette kan ikke endres senere. </b>
-      Det er OK å bruke store bokstaver og mellomrom her. Brukes kun for visning.
+      Det er OK å bruke store bokstaver, Æ/Ø/Å, og mellomrom her. Brukes kun for visning.
     </>,
     ref: 'display_team_name',
-    placeholder: 'Team Brunost'
+    placeholder: 'Team Pålegg Brunost'
   },
   MANAGER: {
     title: 'Teamansvarlig',


### PR DESCRIPTION
<img width="931" alt="Screenshot 2022-02-01 at 15 54 18" src="https://user-images.githubusercontent.com/28501510/151991848-afa773b5-e0bf-430b-bc79-8f7517435c2c.png">

More in-depth and accurate team naming guidelines. 

This is the manual MVP for generating team name suggestions, that we eventually want to make automatic. Even if we make it automatic, this should still be in place, so that users understand how to chose and edit their own team names better based on the suggestions they get.