### PR TITLE
Due to company policy, Kundeservice should be the only support channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM nginx:alpine
 
-RUN apk add --no-cache nodejs yarn
-RUN yarn global add @beam-australia/react-env
+RUN apk update  \
+    && apk upgrade  \
+    && apk add --no-cache nodejs yarn  \
+    && yarn global add @beam-australia/react-env
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY .env docker-entrypoint.sh /var/

--- a/src/content/FAQ.js
+++ b/src/content/FAQ.js
@@ -46,7 +46,7 @@ export const FAQ = [
   {
     header: 'Hva om jeg trenger hjelp underveis?',
     text: <p>
-      Snakk med oss på <a href={UI.SLACK_URL}>#hjelp_dapla</a> så finner vi ut av
+      Send en epost til <a href={UI.KUNDESERVICE_MAIL}>Kundeservice</a> så finner vi ut av
       det.
     </p>
   },
@@ -61,16 +61,15 @@ export const FAQ = [
   {
     header: 'Hva om jeg ønsker å gjøre endringer på bestillingen?',
     text: <p>
-      Legg inn en kommentar på saken din (som du får en lenke til på slutten av veilederen), alternativt snakk med oss
-      på <a href={UI.SLACK_URL}>#hjelp_dapla</a>.
+      Legg inn en kommentar på saken din (som du får en lenke til på slutten av veilederen), alternativt send en epost
+      til <a href={UI.KUNDESERVICE_MAIL}>Kundeservice</a>.
     </p>
   },
   {
     header: 'Kan jeg bruke denne veilederen for å gjøre endringer i et team på et senere tidspunkt?',
     text: <p>
       Foreløpig er denne veilederen kun ment for opprettelse av nye team. Endring på tjenestene foretas fra GitHub.
-      Dokumentasjon for hvordan dette gjøres vil komme på plass etter hvert. Snakk med oss
-      på <a href={UI.SLACK_URL}>#hjelp_dapla</a> hvis du lurer på noe.
+      Dokumentasjon for hvordan dette gjøres vil komme på plass etter hvert.
     </p>
   },
   {

--- a/src/content/STEP_0.js
+++ b/src/content/STEP_0.js
@@ -1,7 +1,5 @@
 import { Tooltip } from 'primereact/tooltip'
 
-import { UI } from './UI'
-
 export const STEP_0 = {
   TEXT: <>
     <p>

--- a/src/content/STEP_0.js
+++ b/src/content/STEP_0.js
@@ -23,12 +23,7 @@ export const STEP_0 = {
     </p>
     <p>
       Nedenfor har vi samlet noen spørsmål og svar som forklarer litt mer om Dapla-team og prosessen med å komme i
-      gang. Vi anbefaler at du leser gjennom disse før du starter veilederen. Send oss gjerne flere spørsmål i
-      kanalen <a href={UI.SLACK_URL}>#hjelp_dapla</a> på Slack dersom noe er uklart.
-    </p>
-    <p>
-      Hvis du ikke har tilgang til Slack kan du alternativt sende en epost
-      til <a href={UI.SLACK_MAIL}>denne adressen</a>.
+      gang. Vi anbefaler at du leser gjennom disse før du starter veilederen.
     </p>
   </>
 }

--- a/src/content/STEP_6.js
+++ b/src/content/STEP_6.js
@@ -14,7 +14,7 @@ export const STEP_6 = {
       Teamansvarlig vil få beskjed når alt er klart.
     </p>
     <p>
-      Spør oss på <a href={UI.SLACK_URL}>#hjelp_dapla</a> om du lurer på noe,
+      Send en epost til <a href={UI.KUNDESERVICE_MAIL}>Kundeservice</a> om du lurer på noe,
       eller legg inn en kommentar på <a href={link}>saken</a>.
     </p>
     <p>

--- a/src/content/UI.js
+++ b/src/content/UI.js
@@ -6,8 +6,7 @@ export const UI = {
   TRY_AGAIN: 'Prøv på nytt',
   REQUIRED: '#ff5757',
   WARNING: '#cc8925',
-  SLACK_URL: 'https://ssb-norge.slack.com/archives/C015E7B4YS0',
-  SLACK_MAIL: 'mailto:hjelp_dapla-aaaace52ybb7ih4k4mdp5sj7yy@ssb-norge.slack.com',
+  KUNDESERVICE_MAIL: 'mailto:kundeservice@ssb.no',
   CHARS: 'tegn',
   DAPLA_GUIDE_URL: 'https://github.com/statisticsnorway/kurs-ssb-dapla-veileder',
   OVERRIDE: 'Overstyr teknisk teamnavn?'

--- a/src/content/WIZARD.js
+++ b/src/content/WIZARD.js
@@ -59,8 +59,7 @@ export const WIZARD = {
     title: 'Tjenester',
     description: <p style={{ fontSize: '0.85rem' }} className="mb-4">
       Velg tjenestene teamet har behov for. Det er mulig å legge til tjenester senere, men det er en fordel om du
-      identifiserer de du trenger allerede nå. Dersom du er usikker, spør oss
-      på <a href={UI.SLACK_URL}>#hjelp_dapla</a>. Det vil komme flere tjenester
+      identifiserer de du trenger allerede nå. Det vil komme flere tjenester
       etterhvert, som kan legges til for teamet når som helst. Foreløpig er det kun <em>Transfer Service</em> som
       finnes.
     </p>,

--- a/src/content/WIZARD.js
+++ b/src/content/WIZARD.js
@@ -1,5 +1,3 @@
-import { UI } from './UI'
-
 export const WIZARD = {
   TEAM_NAME: {
     title: 'Teamnavn',


### PR DESCRIPTION
Removed references to Slack channels.