### PR TITLE
Remove curl from base image to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM nginx:1.23.3-alpine
 RUN apk update  \
     && apk upgrade  \
     && apk add --no-cache nodejs yarn  \
-    && yarn global add @beam-australia/react-env
+    && yarn global add @beam-australia/react-env \
+    && apk del curl
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY .env docker-entrypoint.sh /var/


### PR DESCRIPTION
Removed curl from the base image to address the following vulnerabilities:

- [CVE-2023-23914](https://www.cve.org/CVERecord?id=CVE-2023-23914)
- [CVE-2023-23915](https://www.cve.org/CVERecord?id=CVE-2023-23915)
- [CVE-2023-23916](https://www.cve.org/CVERecord?id=CVE-2023-23916)