### PR TITLE
Run container as user(nginx) with limited permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,8 @@ RUN chown -R nginx:nginx /var/cache/nginx && \
 
 USER nginx
 
-# Expose the port
 EXPOSE 8180
 
 ENTRYPOINT ["sh", "/var/docker-entrypoint.sh"]
 
-# Define the command to start NGINX
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
+# Build stage
 FROM nginx:1.24-alpine
 
-RUN apk update  \
-    && apk upgrade  \
-    && apk add --no-cache nodejs yarn  \
-    && yarn global add @beam-australia/react-env \
-    && apk del curl
+RUN apk update && apk upgrade && \
+    apk add --no-cache nodejs yarn && \
+    yarn global add @beam-australia/react-env && \
+    apk del curl
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY .env docker-entrypoint.sh /var/
 COPY /build /usr/share/nginx/html
 
+
+# Change ownership and permissions for NGINX directories
+RUN chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/run/nginx.pid && \
+    chown -R nginx:nginx /usr/share/nginx/html/__ENV.js
+
+USER nginx
+
+# Expose the port
 EXPOSE 8180
 
 ENTRYPOINT ["sh", "/var/docker-entrypoint.sh"]
 
+# Define the command to start NGINX
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This adjustment closely resembles the changes described in the Medium article below. The only difference is that we need to grant the nginx user r+w access to '/usr/share/nginx/html/__ENV.js' because it is change at runtime. Without it we get this error when starting the container:

```
react-env: Writing runtime env ///usr/share/nginx/html/__ENV.js
node:internal/fs/utils:350
    throw err;
    ^

Error: EACCES: permission denied, open '///usr/share/nginx/html/__ENV.js'
```
This should resolve [issue#78](https://github.com/statisticsnorway/dapla-start-ui/issues/78)

### Reference
- [How to Run Nginx for Root & Non-Root](https://medium.com/kocsistem/how-to-run-nginx-for-root-non-root-5ceb13db6d41)